### PR TITLE
Support vertical world growth and scrolling camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # pymine
-Simple minecraft clone to learn python
+
+A colourful 2D Minecraft / Super Mario inspired sandbox built with
+pygame.  The codebase is intentionally compact, extensively commented and
+split into a pygame free logic layer so Python beginners can experiment
+without digging through framework specifics.
+
+## Features
+
+* Endless, pastel landscape that scrolls beneath the player while preserving a cosy handcrafted spawn area.
+* Terrain now flows both horizontally and vertically – wander into new territory or build skyward/deep underground and fresh columns are generated on demand.
+* Five block inventory (selectable with keys 1-5) with left click to place and right click to remove blocks.
+* Rectangular crosshair that snaps to the grid and respects a 5x5 build radius around the player.
+* Responsive controls with jumping, crouching and a double-space flight toggle.
+* Relaxing rainbow of colour themes crafted with pastel harmony – cycle them with the ``T`` key.
+
+## Getting started
+
+This repository uses a standard [uv](https://github.com/astral-sh/uv)
+layout.  Install dependencies and run the game with:
+
+```bash
+uv pip install -r pyproject.toml
+uv run pymine
+```
+
+If you prefer using plain `pip`, install the project in editable mode and
+run the script entry point:
+
+```bash
+pip install -e .
+pymine
+```
+
+## Running the tests
+
+Automated tests cover the pygame independent mechanics:
+
+```bash
+uv run pytest
+```
+
+## Controls
+
+* **Arrow keys / WASD** – move left/right (and up/down when in flight mode)
+* **Space** – jump
+* **Double space** – toggle flight mode
+* **Shift** – crouch for precise movement
+* **Mouse** – position the crosshair, left click to place, right click to remove
+* **1-5** – select blocks from the inventory bar
+* **T** – cycle through the curated relaxing colour themes
+* **Escape** – quit the game

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "pymine"
+version = "0.1.0"
+description = "A colourful 2D Minecraft / Super Mario inspired sandbox built with pygame."
+authors = [
+  { name = "OpenAI Assistant" }
+]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "pygame>=2.5.0"
+]
+
+[project.scripts]
+pymine = "pymine.game:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-ra"

--- a/src/pymine/__init__.py
+++ b/src/pymine/__init__.py
@@ -1,0 +1,5 @@
+"""Top level package for the colourful PyMine sandbox."""
+
+from . import world
+
+__all__ = ["world"]

--- a/src/pymine/game.py
+++ b/src/pymine/game.py
@@ -1,0 +1,452 @@
+"""Pygame front end for the colourful sandbox world.
+
+The game is intentionally small so that new Python programmers can read
+through the code and experiment with their own features.  The logic is
+split into two layers: :mod:`pymine.world` contains the testable data
+structures while this module deals with drawing, controls and physics.
+"""
+from __future__ import annotations
+
+import math
+import time
+import colorsys
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import pygame
+
+from .physics import InputState, update_player_physics
+from .world import (
+    Inventory,
+    PlayerState,
+    build_palette,
+    create_prebuilt_world,
+    within_build_radius,
+)
+
+# --- Configuration -------------------------------------------------------
+
+BLOCK_SIZE = 24
+WORLD_WIDTH = 40
+WORLD_HEIGHT = 30
+SCREEN_SIZE = (WORLD_WIDTH * BLOCK_SIZE, WORLD_HEIGHT * BLOCK_SIZE)
+DOUBLE_TAP_WINDOW = 0.3
+BUILD_RADIUS = 2
+
+@dataclass(frozen=True)
+class Theme:
+    """Colour theme applied to the entire front end."""
+
+    name: str
+    base_hue: float
+    background_top: Tuple[int, int, int]
+    background_bottom: Tuple[int, int, int]
+    crosshair_color: Tuple[int, int, int]
+    crosshair_outline: Tuple[int, int, int]
+    player_color: Tuple[int, int, int]
+    hud_shadow: Tuple[int, int, int]
+    hud_text: Tuple[int, int, int]
+    hud_panel: Tuple[int, int, int, int]
+    selection_glow: Tuple[int, int, int]
+def _theme_colour(base_hue: float, *, offset: float, lightness: float, saturation: float) -> Tuple[int, int, int]:
+    r, g, b = colorsys.hls_to_rgb((base_hue + offset) % 1.0, lightness, saturation)
+    return (int(round(r * 255)), int(round(g * 255)), int(round(b * 255)))
+
+
+def create_themes() -> List[Theme]:
+    """Generate soft themes spanning the rainbow of base hues."""
+
+    def theme(name: str, base_hue: float) -> Theme:
+        background_top = _theme_colour(base_hue, offset=-0.03, lightness=0.92, saturation=0.18)
+        background_bottom = _theme_colour(base_hue, offset=0.05, lightness=0.68, saturation=0.22)
+        crosshair_color = _theme_colour(base_hue, offset=0.07, lightness=0.86, saturation=0.24)
+        crosshair_outline = _theme_colour(base_hue, offset=0.07, lightness=0.6, saturation=0.32)
+        player_color = _theme_colour(base_hue, offset=-0.02, lightness=0.35, saturation=0.38)
+        hud_shadow = _theme_colour(base_hue, offset=-0.01, lightness=0.28, saturation=0.34)
+        hud_text = _theme_colour(base_hue, offset=0.12, lightness=0.93, saturation=0.16)
+        hud_panel_rgb = _theme_colour(base_hue, offset=-0.02, lightness=0.23, saturation=0.4)
+        selection_glow = _theme_colour(base_hue, offset=0.18, lightness=0.78, saturation=0.25)
+        return Theme(
+            name=name,
+            base_hue=base_hue,
+            background_top=background_top,
+            background_bottom=background_bottom,
+            crosshair_color=crosshair_color,
+            crosshair_outline=crosshair_outline,
+            player_color=player_color,
+            hud_shadow=hud_shadow,
+            hud_text=hud_text,
+            hud_panel=(*hud_panel_rgb, 200),
+            selection_glow=selection_glow,
+        )
+
+    return [
+        theme("Azure Coast", 0.58),
+        theme("Rose Dawn", 0.01),
+        theme("Amber Drift", 0.09),
+        theme("Sunlit Meadow", 0.16),
+        theme("Verdant Mist", 0.28),
+        theme("Indigo Veil", 0.67),
+        theme("Violet Bloom", 0.78),
+    ]
+
+
+def gradient_background(surface: pygame.Surface, theme: Theme) -> None:
+    """Draw a subtle vertical gradient sky."""
+
+    top = pygame.Color(*theme.background_top)
+    bottom = pygame.Color(*theme.background_bottom)
+    height = surface.get_height()
+    for y in range(height):
+        blend = y / max(1, height - 1)
+        color = pygame.Color(
+            int(top.r + (bottom.r - top.r) * blend),
+            int(top.g + (bottom.g - top.g) * blend),
+            int(top.b + (bottom.b - top.b) * blend),
+        )
+        pygame.draw.line(surface, color, (0, y), (surface.get_width(), y))
+
+
+def draw_world(surface: pygame.Surface, world, camera_x: float, camera_y: float) -> None:
+    """Render the visible slice of the endless map."""
+
+    screen_width = surface.get_width()
+    start_column = int(math.floor(camera_x / BLOCK_SIZE))
+    column_offset = -(camera_x - start_column * BLOCK_SIZE)
+    first_column = start_column - 1
+    columns_to_draw = WORLD_WIDTH + 3
+    world.ensure_range(first_column, columns_to_draw)
+
+    screen_height = surface.get_height()
+    start_row = int(math.floor(camera_y / BLOCK_SIZE))
+    row_offset = -(camera_y - start_row * BLOCK_SIZE)
+    first_row = start_row - 1
+    rows_to_draw = WORLD_HEIGHT + 3
+    world.ensure_vertical_range(first_row, rows_to_draw)
+
+    for index in range(columns_to_draw):
+        world_x = first_column + index
+        screen_x = column_offset + (index - 1) * BLOCK_SIZE
+        if screen_x <= -BLOCK_SIZE or screen_x >= screen_width:
+            continue
+        for row in range(rows_to_draw):
+            world_y = first_row + row
+            screen_y = row_offset + (row - 1) * BLOCK_SIZE
+            if screen_y <= -BLOCK_SIZE or screen_y >= screen_height:
+                continue
+            block = world.get(world_x, world_y)
+            if block is None:
+                continue
+            rect = pygame.Rect(int(screen_x), int(screen_y), BLOCK_SIZE, BLOCK_SIZE)
+            pygame.draw.rect(surface, block.color, rect)
+            pygame.draw.rect(surface, (0, 0, 0), rect, 1)
+
+
+def draw_player(
+    surface: pygame.Surface, player: PlayerState, theme: Theme, camera_x: float, camera_y: float
+) -> None:
+    rect = pygame.Rect(
+        int(player.position[0] - camera_x),
+        int(player.position[1] - camera_y),
+        int(player.width),
+        int(player.height),
+    )
+    pygame.draw.rect(surface, theme.player_color, rect, border_radius=4)
+
+
+def draw_crosshair(
+    surface: pygame.Surface,
+    block_pos: Tuple[int, int],
+    theme: Theme,
+    camera_x: float,
+    camera_y: float,
+) -> None:
+    rect = pygame.Rect(
+        int(block_pos[0] * BLOCK_SIZE - camera_x),
+        int(block_pos[1] * BLOCK_SIZE - camera_y),
+        BLOCK_SIZE,
+        BLOCK_SIZE,
+    )
+    pygame.draw.rect(surface, theme.crosshair_color, rect, width=2)
+    pygame.draw.rect(surface, theme.crosshair_outline, rect.inflate(-4, -4), width=2)
+
+
+def draw_inventory(
+    surface: pygame.Surface,
+    font: pygame.font.Font,
+    inventory: Inventory,
+    theme: Theme,
+) -> None:
+    margin = 10
+    slot_size = 48
+    total_width = len(inventory.slots) * slot_size + (len(inventory.slots) - 1) * 8
+    x = (surface.get_width() - total_width) // 2
+    y = surface.get_height() - slot_size - margin
+
+    overlay = pygame.Surface((total_width + 20, slot_size + 20), pygame.SRCALPHA)
+    overlay.fill(theme.hud_panel)
+    surface.blit(overlay, (x - 10, y - 10))
+
+    for index, block in enumerate(inventory.slots):
+        slot_rect = pygame.Rect(x + index * (slot_size + 8), y, slot_size, slot_size)
+        pygame.draw.rect(surface, block.color, slot_rect.inflate(-10, -10), border_radius=8)
+        pygame.draw.rect(surface, theme.hud_shadow, slot_rect, 2, border_radius=8)
+        number = font.render(str(index + 1), True, theme.hud_shadow)
+        surface.blit(number, (slot_rect.x + 4, slot_rect.y + 4))
+        if index == inventory.selected_index:
+            pygame.draw.rect(surface, theme.selection_glow, slot_rect, 3, border_radius=8)
+
+        name_label = font.render(block.name, True, theme.hud_text)
+        label_pos = (slot_rect.centerx - name_label.get_width() // 2, slot_rect.bottom + 2)
+        surface.blit(name_label, label_pos)
+
+
+def draw_status(
+    surface: pygame.Surface,
+    font: pygame.font.Font,
+    player: PlayerState,
+    theme: Theme,
+    theme_name: str,
+) -> None:
+    messages = [
+        "Space: jump  |  Double space: toggle flight",
+        "Shift: crouch  |  1-5: choose block  |  Left click: place  |  Right click: remove",
+        "Press T to relax with a new colour theme",
+        f"Flight mode: {'ON' if player.flight_mode else 'OFF'}  |  Theme: {theme_name}",
+    ]
+    for i, text in enumerate(messages):
+        label = font.render(text, True, theme.hud_shadow)
+        surface.blit(label, (10, 10 + i * (label.get_height() + 4)))
+
+
+def handle_input(keys: Dict[int, bool]) -> InputState:
+    """Translate pygame's key state into our simpler structure."""
+
+    state = InputState()
+    state.left = keys.get(pygame.K_a, False) or keys.get(pygame.K_LEFT, False)
+    state.right = keys.get(pygame.K_d, False) or keys.get(pygame.K_RIGHT, False)
+    state.up = keys.get(pygame.K_w, False) or keys.get(pygame.K_UP, False)
+    state.down = keys.get(pygame.K_s, False) or keys.get(pygame.K_DOWN, False)
+    state.jump = keys.get(pygame.K_SPACE, False)
+    state.crouch = keys.get(pygame.K_LSHIFT, False) or keys.get(pygame.K_RSHIFT, False)
+    return state
+
+
+def clamp(value: float, min_value: float, max_value: float) -> float:
+    return max(min_value, min(max_value, value))
+
+
+def move_player(world, player: PlayerState, dt: float) -> None:
+    """Move the player while preventing them from entering solid tiles."""
+
+    # Horizontal movement
+    player.position[0] += player.velocity[0] * dt
+    if player.velocity[0] > 0:
+        right = player.position[0] + player.width
+        tile_x = int(right // BLOCK_SIZE)
+        y_start = int(player.position[1] // BLOCK_SIZE)
+        y_end = int((player.position[1] + player.height - 1) // BLOCK_SIZE)
+        for tile_y in range(y_start, y_end + 1):
+            if world.is_solid(tile_x, tile_y):
+                player.position[0] = tile_x * BLOCK_SIZE - player.width
+                player.velocity[0] = 0
+                break
+    elif player.velocity[0] < 0:
+        left = player.position[0]
+        tile_x = int(math.floor(left / BLOCK_SIZE))
+        y_start = int(player.position[1] // BLOCK_SIZE)
+        y_end = int((player.position[1] + player.height - 1) // BLOCK_SIZE)
+        for tile_y in range(y_start, y_end + 1):
+            if world.is_solid(tile_x, tile_y):
+                player.position[0] = (tile_x + 1) * BLOCK_SIZE
+                player.velocity[0] = 0
+                break
+
+    # Vertical movement
+    player.position[1] += player.velocity[1] * dt
+    player.on_ground = False
+    if player.velocity[1] > 0:
+        bottom = player.position[1] + player.height
+        tile_y = int(bottom // BLOCK_SIZE)
+        x_start = int(player.position[0] // BLOCK_SIZE)
+        x_end = int((player.position[0] + player.width - 1) // BLOCK_SIZE)
+        for tile_x in range(x_start, x_end + 1):
+            if world.is_solid(tile_x, tile_y):
+                player.position[1] = tile_y * BLOCK_SIZE - player.height
+                player.velocity[1] = 0
+                player.on_ground = True
+                break
+    elif player.velocity[1] < 0:
+        top = player.position[1]
+        tile_y = int(math.floor(top / BLOCK_SIZE))
+        x_start = int(player.position[0] // BLOCK_SIZE)
+        x_end = int((player.position[0] + player.width - 1) // BLOCK_SIZE)
+        for tile_x in range(x_start, x_end + 1):
+            if world.is_solid(tile_x, tile_y):
+                player.position[1] = (tile_y + 1) * BLOCK_SIZE
+                player.velocity[1] = 0
+                break
+
+
+def build_crosshair(
+    player: PlayerState, mouse_pos: Tuple[int, int], camera_x: float, camera_y: float
+) -> Tuple[int, int]:
+    """Snap the mouse position to the grid and clamp to the build radius."""
+
+    mouse_block = (
+        int((mouse_pos[0] + camera_x) // BLOCK_SIZE),
+        int((mouse_pos[1] + camera_y) // BLOCK_SIZE),
+    )
+    player_block = (
+        int((player.position[0] + player.width / 2) // BLOCK_SIZE),
+        int((player.position[1] + player.height / 2) // BLOCK_SIZE),
+    )
+    dx = int(clamp(mouse_block[0] - player_block[0], -BUILD_RADIUS, BUILD_RADIUS))
+    dy = int(clamp(mouse_block[1] - player_block[1], -BUILD_RADIUS, BUILD_RADIUS))
+    target_x = player_block[0] + dx
+    target_y = player_block[1] + dy
+    return target_x, target_y
+
+
+def block_rect(block_pos: Tuple[int, int]) -> pygame.Rect:
+    return pygame.Rect(block_pos[0] * BLOCK_SIZE, block_pos[1] * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE)
+
+
+def player_intersects_block(player: PlayerState, block_pos: Tuple[int, int]) -> bool:
+    rect = block_rect(block_pos)
+    player_rect = pygame.Rect(
+        player.position[0],
+        player.position[1],
+        player.width,
+        player.height,
+    )
+    return player_rect.colliderect(rect)
+
+
+def apply_palette_to_world(world, palette) -> None:
+    """Replace themeable blocks in the world with the active palette."""
+
+    if hasattr(world, "retheme"):
+        world.retheme(palette)
+        return
+
+    replacements = {block.name: block for block in palette}
+    for y, row in enumerate(world.tiles):
+        for x, block in enumerate(row):
+            if block is None:
+                continue
+            if block.name in replacements:
+                world.tiles[y][x] = replacements[block.name]
+
+
+def main() -> None:
+    pygame.init()
+    pygame.display.set_caption("PyMine - Colourful Sandbox")
+    screen = pygame.display.set_mode(SCREEN_SIZE)
+    clock = pygame.time.Clock()
+
+    themes = create_themes()
+    theme_index = 0
+    theme = themes[theme_index]
+    pygame.display.set_caption(f"PyMine - {theme.name}")
+
+    palette = build_palette(theme.base_hue)
+    inventory = Inventory(slots=list(palette))
+    world = create_prebuilt_world(WORLD_WIDTH, WORLD_HEIGHT, palette)
+
+    player = PlayerState(position=[BLOCK_SIZE * 3.0, BLOCK_SIZE * 10.0], velocity=[0.0, 0.0], width=BLOCK_SIZE * 0.6, height=BLOCK_SIZE * 0.9)
+
+    fonts = {
+        "hud": pygame.font.SysFont("arial", 18),
+        "inventory": pygame.font.SysFont("arial", 16),
+    }
+
+    running = True
+    last_space_time = 0.0
+    camera_x = 0.0
+    camera_y = 0.0
+
+    while running:
+        dt = clock.tick(60) / 1000.0
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if pygame.K_1 <= event.key <= pygame.K_5:
+                    slot = event.key - pygame.K_1
+                    if slot < len(inventory.slots):
+                        inventory.select(slot)
+                if event.key == pygame.K_SPACE:
+                    now = time.time()
+                    if now - last_space_time < DOUBLE_TAP_WINDOW:
+                        player.toggle_flight()
+                        last_space_time = 0.0
+                    else:
+                        last_space_time = now
+                if event.key == pygame.K_ESCAPE:
+                    running = False
+                if event.key == pygame.K_t:
+                    theme_index = (theme_index + 1) % len(themes)
+                    theme = themes[theme_index]
+                    pygame.display.set_caption(f"PyMine - {theme.name}")
+                    palette = build_palette(theme.base_hue)
+                    selected_slot = inventory.selected_index
+                    inventory.slots = list(palette)
+                    inventory.selected_index = min(selected_slot, len(inventory.slots) - 1)
+                    apply_palette_to_world(world, palette)
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                target_block = build_crosshair(
+                    player, pygame.mouse.get_pos(), camera_x, camera_y
+                )
+                player_block = (
+                    int((player.position[0] + player.width / 2) // BLOCK_SIZE),
+                    int((player.position[1] + player.height / 2) // BLOCK_SIZE),
+                )
+                if not within_build_radius(player_block, target_block, BUILD_RADIUS):
+                    continue
+                if player_intersects_block(player, target_block):
+                    continue
+
+                if event.button == 1:
+                    if world.get(*target_block) is None:
+                        world.set(*target_block, inventory.selected)
+                elif event.button == 3:
+                    if world.get(*target_block) is not None:
+                        world.set(*target_block, None)
+
+        pressed = pygame.key.get_pressed()
+        key_state = {key: pressed[key] for key in range(len(pressed))}
+        inputs = handle_input(key_state)
+
+        update_player_physics(player, inputs, dt)
+
+        move_player(world, player, dt)
+
+        # Keep the camera centred around the player as the world scrolls.
+        camera_x = player.position[0] + player.width / 2 - SCREEN_SIZE[0] / 2
+        camera_y = player.position[1] + player.height / 2 - SCREEN_SIZE[1] / 2
+
+        min_camera_y = world.top * BLOCK_SIZE
+        max_camera_y = world.bottom * BLOCK_SIZE + BLOCK_SIZE - SCREEN_SIZE[1]
+        if max_camera_y < min_camera_y:
+            max_camera_y = min_camera_y
+        camera_y = clamp(camera_y, min_camera_y, max_camera_y)
+
+        gradient_background(screen, theme)
+        draw_world(screen, world, camera_x, camera_y)
+        draw_player(screen, player, theme, camera_x, camera_y)
+        crosshair_block = build_crosshair(
+            player, pygame.mouse.get_pos(), camera_x, camera_y
+        )
+        draw_crosshair(screen, crosshair_block, theme, camera_x, camera_y)
+        draw_inventory(screen, fonts["inventory"], inventory, theme)
+        draw_status(screen, fonts["hud"], player, theme, theme.name)
+
+        pygame.display.flip()
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pymine/physics.py
+++ b/src/pymine/physics.py
@@ -1,0 +1,79 @@
+"""Physics helpers shared between the core game and unit tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .world import PlayerState
+
+GRAVITY = 1200.0
+"""Downward acceleration applied when the player is not in flight."""
+
+MOVE_SPEED = 180.0
+FLIGHT_SPEED = 200.0
+JUMP_SPEED = 480.0
+"""Initial upward launch speed when jumping (roughly a four block leap)."""
+
+MAX_FALL_SPEED = 900.0
+"""Terminal velocity in pixels per second so falling feels responsive."""
+
+
+@dataclass
+class InputState:
+    """Tracks pressed keys for a frame in a pygame agnostic way."""
+
+    left: bool = False
+    right: bool = False
+    up: bool = False
+    down: bool = False
+    jump: bool = False
+    crouch: bool = False
+
+
+def update_player_physics(player: PlayerState, inputs: InputState, dt: float) -> None:
+    """Update player velocity based on the controls and elapsed time.
+
+    The function keeps the signs of the movement values intuitive for the
+    coordinate system used by pygame (``y`` increases downward).  Jumping
+    therefore sets a *negative* velocity and gravity adds a *positive*
+    acceleration so that the player initially moves upward before being
+    pulled back toward the terrain.  Flight mode overrides the gravitational
+    integration and allows direct vertical steering.
+    """
+
+    # Horizontal behaviour is identical in both grounded and flight states.
+    player.crouching = inputs.crouch and not player.flight_mode
+    move_dir = 0
+    if inputs.left:
+        move_dir -= 1
+    if inputs.right:
+        move_dir += 1
+    speed = MOVE_SPEED * (0.5 if player.crouching else 1.0)
+    player.velocity[0] = move_dir * (FLIGHT_SPEED if player.flight_mode else speed)
+
+    # Vertical behaviour switches between flight and gravity driven motion.
+    if player.flight_mode:
+        vertical_dir = 0
+        if inputs.up:
+            vertical_dir -= 1
+        if inputs.down:
+            vertical_dir += 1
+        player.velocity[1] = vertical_dir * FLIGHT_SPEED
+    else:
+        if inputs.jump and player.on_ground:
+            player.velocity[1] = -JUMP_SPEED
+            player.on_ground = False
+        else:
+            player.velocity[1] = min(player.velocity[1] + GRAVITY * dt, MAX_FALL_SPEED)
+
+
+__all__ = [
+    "FLIGHT_SPEED",
+    "GRAVITY",
+    "InputState",
+    "JUMP_SPEED",
+    "MAX_FALL_SPEED",
+    "MOVE_SPEED",
+    "update_player_physics",
+]
+

--- a/src/pymine/world.py
+++ b/src/pymine/world.py
@@ -1,0 +1,369 @@
+"""Core game logic for the colourful sandbox world.
+
+This module purposely keeps pygame specific code out so that the
+behaviour can be unit tested.  The :mod:`pymine.game` module provides the
+interactive pygame front end.  Colour palettes can be generated from a
+base hue so that the front end can present multiple relaxing themes
+without changing the underlying mechanics.
+"""
+from __future__ import annotations
+
+import colorsys
+import random
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class BlockType:
+    """Represents a single type of block.
+
+    Attributes
+    ----------
+    name:
+        Human readable name displayed in the HUD.
+    color:
+        RGB tuple used for drawing the block.
+    solid:
+        Whether the block obstructs the player.
+    """
+
+    name: str
+    color: Tuple[int, int, int]
+    solid: bool = True
+
+
+class BlockPalette:
+    """Palette containing every buildable block type.
+
+    The palette exposes dictionary style access by name and keeps the
+    insertion order to allow predictable inventory listings.
+    """
+
+    def __init__(self, blocks: Iterable[Tuple[str, BlockType]]):
+        self._blocks: Dict[str, BlockType] = dict(blocks)
+
+    def __getitem__(self, key: str) -> BlockType:
+        return self._blocks[key]
+
+    def __iter__(self) -> Iterable[BlockType]:
+        return iter(self._blocks.values())
+
+    def names(self) -> List[str]:
+        return list(self._blocks.keys())
+
+    def __len__(self) -> int:
+        return len(self._blocks)
+
+
+@dataclass
+class Inventory:
+    """A small, beginner friendly inventory implementation."""
+
+    slots: List[BlockType]
+    selected_index: int = 0
+
+    def select(self, index: int) -> None:
+        if not 0 <= index < len(self.slots):
+            raise IndexError("Inventory slot out of range")
+        self.selected_index = index
+
+    @property
+    def selected(self) -> BlockType:
+        return self.slots[self.selected_index]
+
+
+@dataclass
+class WorldGrid:
+    """Stores the tile based world layout."""
+
+    width: int
+    height: int
+    default_block: Optional[BlockType]
+    tiles: List[List[Optional[BlockType]]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.tiles = [
+            [self.default_block for _ in range(self.width)]
+            for _ in range(self.height)
+        ]
+
+    def in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def get(self, x: int, y: int) -> Optional[BlockType]:
+        if not self.in_bounds(x, y):
+            raise IndexError("Coordinate outside of world")
+        return self.tiles[y][x]
+
+    def set(self, x: int, y: int, block: Optional[BlockType]) -> None:
+        if not self.in_bounds(x, y):
+            raise IndexError("Coordinate outside of world")
+        self.tiles[y][x] = block
+
+    def is_solid(self, x: int, y: int) -> bool:
+        if not self.in_bounds(x, y):
+            return True
+        block = self.tiles[y][x]
+        return bool(block and block.solid)
+
+
+class InfiniteWorld:
+    """Procedurally extends the horizontal world as the player explores."""
+
+    def __init__(
+        self,
+        *,
+        height: int,
+        palette: BlockPalette,
+        default_block: Optional[BlockType] = None,
+    ) -> None:
+        self._top = 0
+        self._bottom = height - 1
+        self.default_block = default_block
+        self._columns: Dict[int, List[Optional[BlockType]]] = {}
+        self._palette_blocks: List[BlockType] = []
+        self.horizon = height // 2 + 4
+        self.ground_block = BlockType("Soil", (124, 98, 76))
+        self.grass_block = BlockType("Grass", (118, 158, 108))
+        self.stone_block = BlockType("Stone", (105, 110, 125))
+        self.retheme(palette)
+
+    @property
+    def top(self) -> int:
+        return self._top
+
+    @property
+    def bottom(self) -> int:
+        return self._bottom
+
+    @property
+    def height(self) -> int:
+        return self._bottom - self._top + 1
+
+    def _base_block_for(self, x: int, y: int) -> Optional[BlockType]:
+        """Return the default block generated for ``(x, y)``."""
+
+        block: Optional[BlockType]
+        if y < self.horizon:
+            block = self.default_block
+        else:
+            depth = y - self.horizon
+            if depth == 0:
+                block = self.grass_block
+            elif depth < 6:
+                block = self.ground_block
+            else:
+                block = self.stone_block
+
+        # Decorative floating platforms with palette colours.
+        pattern_index = x // 9
+        platform_phase = x % 9
+        if platform_phase in {0, 1, 2}:
+            height_offset = pattern_index % 3
+            platform_y = self.horizon - 4 - height_offset * 2
+            if y == platform_y:
+                platform_block = self._palette_choice(pattern_index)
+                if platform_block is not None:
+                    return platform_block
+
+        # Gentle crystal outcrops just above the grass.
+        rng = random.Random((x + 3000) * 92821)
+        spawn_crystal = rng.random() < 0.1
+        spawn_stack = rng.random() < 0.5 if spawn_crystal else False
+        if spawn_crystal:
+            if y == self.horizon - 1:
+                crystal = self._palette_choice(x)
+                if crystal is not None:
+                    return crystal
+            if spawn_stack and y == self.horizon - 2:
+                topper = self._palette_choice(x + 1)
+                if topper is not None:
+                    return topper
+
+        # Mario-like staircase near the origin to keep the tutorial feel.
+        if -2 <= x <= 8:
+            step = max(0, 8 - x)
+            stair_y = self.horizon - 1 - step
+            if y == stair_y:
+                return self.stone_block
+
+        return block
+
+    def _generate_column(self, x: int, top: int, bottom: int) -> List[Optional[BlockType]]:
+        return [self._base_block_for(x, y) for y in range(top, bottom + 1)]
+
+    def _expand_columns_to(self, new_top: int, new_bottom: int) -> None:
+        for x, column in self._columns.items():
+            if new_top < self._top:
+                prepend = [self._base_block_for(x, y) for y in range(new_top, self._top)]
+                column[0:0] = prepend
+            if new_bottom > self._bottom:
+                column.extend(
+                    self._base_block_for(x, y)
+                    for y in range(self._bottom + 1, new_bottom + 1)
+                )
+        self._top = min(self._top, new_top)
+        self._bottom = max(self._bottom, new_bottom)
+
+    def _ensure_vertical_bounds(self, y: int) -> None:
+        if y < self._top or y > self._bottom:
+            new_top = min(self._top, y)
+            new_bottom = max(self._bottom, y)
+            self._expand_columns_to(new_top, new_bottom)
+
+    def _palette_choice(self, index: int) -> Optional[BlockType]:
+        if not self._palette_blocks:
+            return None
+        return self._palette_blocks[index % len(self._palette_blocks)]
+
+    def _ensure_column(self, x: int) -> None:
+        if x in self._columns:
+            return
+        self._columns[x] = self._generate_column(x, self._top, self._bottom)
+
+    def ensure_range(self, start_x: int, width: int) -> None:
+        for x in range(start_x, start_x + width):
+            self._ensure_column(x)
+
+    def column(self, x: int) -> List[Optional[BlockType]]:
+        """Return a full column, generating it when necessary."""
+
+        self._ensure_column(x)
+        return self._columns[x]
+
+    def get(self, x: int, y: int) -> Optional[BlockType]:
+        self._ensure_vertical_bounds(y)
+        self._ensure_column(x)
+        return self._columns[x][y - self._top]
+
+    def set(self, x: int, y: int, block: Optional[BlockType]) -> None:
+        self._ensure_vertical_bounds(y)
+        self._ensure_column(x)
+        self._columns[x][y - self._top] = block
+
+    def is_solid(self, x: int, y: int) -> bool:
+        self._ensure_vertical_bounds(y)
+        self._ensure_column(x)
+        index = y - self._top
+        block = self._columns[x][index]
+        return bool(block and block.solid)
+
+    def iter_window(self, start_x: int, width: int) -> Iterable[List[Optional[BlockType]]]:
+        self.ensure_range(start_x, width)
+        for y in range(self._top, self._bottom + 1):
+            yield [self.get(x, y) for x in range(start_x, start_x + width)]
+
+    def ensure_vertical_range(self, start_y: int, height: int) -> None:
+        end_y = start_y + height - 1
+        self._ensure_vertical_bounds(start_y)
+        self._ensure_vertical_bounds(end_y)
+
+    def retheme(self, palette: BlockPalette) -> None:
+        self.palette = palette
+        self._palette_blocks = list(palette)
+        replacements = {block.name: block for block in self._palette_blocks}
+        for column in self._columns.values():
+            for index, block in enumerate(column):
+                if block is not None and block.name in replacements:
+                    column[index] = replacements[block.name]
+
+
+@dataclass
+class PlayerState:
+    """Tracks the player's physical state independent of pygame."""
+
+    position: List[float]
+    velocity: List[float]
+    width: float
+    height: float
+    on_ground: bool = False
+    crouching: bool = False
+    flight_mode: bool = False
+
+    def rect(self) -> Tuple[float, float, float, float]:
+        return (*self.position, self.width, self.height)
+
+    def toggle_flight(self) -> bool:
+        self.flight_mode = not self.flight_mode
+        if self.flight_mode:
+            self.velocity[1] = 0.0
+        return self.flight_mode
+
+
+def _soft_colour(hue: float, lightness: float, saturation: float) -> Tuple[int, int, int]:
+    """Convert an HLS colour to an RGB tuple tuned for soft palettes."""
+
+    r, g, b = colorsys.hls_to_rgb(hue % 1.0, lightness, saturation)
+    return (int(round(r * 255)), int(round(g * 255)), int(round(b * 255)))
+
+
+def build_palette(base_hue: Optional[float] = None) -> BlockPalette:
+    """Create a harmonic block palette derived from a base hue.
+
+    Parameters
+    ----------
+    base_hue:
+        Hue value in the range ``0-1`` used to tint the palette.  When no
+        value is provided a calming blue-green hue is used by default.
+    """
+
+    if base_hue is None:
+        base_hue = 0.58  # Gentle teal by default
+
+    palette_data = [
+        (
+            "cloudstone",
+            BlockType("Cloudstone", _soft_colour(base_hue - 0.05, 0.74, 0.22)),
+        ),
+        (
+            "petal_clay",
+            BlockType("Petal Clay", _soft_colour(base_hue, 0.63, 0.28)),
+        ),
+        (
+            "moss_brick",
+            BlockType("Moss Brick", _soft_colour(base_hue + 0.07, 0.58, 0.26)),
+        ),
+        (
+            "glass_tile",
+            BlockType("Glass Tile", _soft_colour(base_hue + 0.14, 0.68, 0.18)),
+        ),
+        (
+            "dune_sand",
+            BlockType("Dune Sand", _soft_colour(base_hue - 0.12, 0.82, 0.18)),
+        ),
+    ]
+    return BlockPalette(palette_data)
+
+
+def create_prebuilt_world(width: int, height: int, palette: BlockPalette) -> InfiniteWorld:
+    """Generate the endless colourful landscape."""
+
+    world = InfiniteWorld(height=height, palette=palette, default_block=None)
+
+    # Prepare enough columns so the opening view feels handcrafted.  The
+    # generator will take over as soon as the player ventures farther afield.
+    preload_start = -width
+    world.ensure_range(preload_start, width * 3)
+    return world
+
+
+def within_build_radius(player_block: Tuple[int, int], target_block: Tuple[int, int], radius: int = 2) -> bool:
+    """Check whether the target is within a square radius of the player."""
+
+    dx = abs(player_block[0] - target_block[0])
+    dy = abs(player_block[1] - target_block[1])
+    return max(dx, dy) <= radius
+
+
+__all__ = [
+    "BlockPalette",
+    "BlockType",
+    "Inventory",
+    "PlayerState",
+    "WorldGrid",
+    "InfiniteWorld",
+    "build_palette",
+    "create_prebuilt_world",
+    "within_build_radius",
+]

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,0 +1,63 @@
+"""Regression tests for the pygame facing physics helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from pymine.physics import (
+    FLIGHT_SPEED,
+    GRAVITY,
+    JUMP_SPEED,
+    MAX_FALL_SPEED,
+    InputState,
+    update_player_physics,
+)
+from pymine.world import PlayerState
+
+
+def make_player(*, on_ground: bool = True, flight_mode: bool = False) -> PlayerState:
+    return PlayerState(
+        position=[0.0, 0.0],
+        velocity=[0.0, 0.0],
+        width=12.0,
+        height=20.0,
+        on_ground=on_ground,
+        flight_mode=flight_mode,
+    )
+
+
+def test_left_and_right_inputs_apply_expected_signs() -> None:
+    player = make_player()
+    update_player_physics(player, InputState(left=True), 1 / 60)
+    assert player.velocity[0] < 0
+
+    update_player_physics(player, InputState(right=True), 1 / 60)
+    assert player.velocity[0] > 0
+
+
+def test_jump_initialises_negative_vertical_velocity() -> None:
+    player = make_player(on_ground=True)
+    update_player_physics(player, InputState(jump=True), 1 / 60)
+    assert player.velocity[1] == pytest.approx(-JUMP_SPEED)
+    assert not player.on_ground
+
+
+def test_gravity_accumulates_positive_velocity_until_terminal() -> None:
+    player = make_player(on_ground=False)
+    dt = 1 / 30
+    update_player_physics(player, InputState(), dt)
+    assert player.velocity[1] == pytest.approx(min(GRAVITY * dt, MAX_FALL_SPEED))
+
+    # Apply a large delta time to force the clamp.
+    update_player_physics(player, InputState(), 5.0)
+    assert player.velocity[1] == MAX_FALL_SPEED
+
+
+def test_flight_controls_use_correct_signs() -> None:
+    player = make_player(on_ground=False, flight_mode=True)
+    update_player_physics(player, InputState(up=True), 1 / 60)
+    assert player.velocity[1] == -FLIGHT_SPEED
+
+    update_player_physics(player, InputState(down=True), 1 / 60)
+    assert player.velocity[1] == FLIGHT_SPEED
+

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,0 +1,179 @@
+"""Tests for the pygame independent mechanics."""
+
+import pytest
+
+from pymine import world
+
+
+def test_inventory_selection():
+    palette = world.build_palette()
+    inventory = world.Inventory(slots=list(palette))
+    inventory.select(2)
+    assert inventory.selected == list(palette)[2]
+
+
+def test_inventory_out_of_range():
+    palette = world.build_palette()
+    inventory = world.Inventory(slots=list(palette))
+    try:
+        inventory.select(10)
+    except IndexError:
+        pass
+    else:
+        raise AssertionError("Selecting an invalid slot should raise IndexError")
+
+
+def test_world_generation_layout():
+    palette = world.build_palette()
+    infinite = world.create_prebuilt_world(40, 30, palette)
+    horizon = infinite.horizon
+
+    # Grass layer should exist across a generous span both directions.
+    for x in range(-20, 20):
+        assert infinite.get(x, horizon) is not None
+
+    # Air above the horizon should contain some floating palette blocks without filling the sky.
+    sky_blocks = 0
+    for y in range(horizon):
+        for x in range(-20, 20):
+            block = infinite.get(x, y)
+            if block is not None:
+                sky_blocks += 1
+    assert sky_blocks > 0
+    assert sky_blocks < horizon * 40
+
+
+def test_infinite_world_expands_both_directions():
+    palette = world.build_palette()
+    infinite = world.create_prebuilt_world(40, 30, palette)
+    horizon = infinite.horizon
+
+    assert infinite.get(250, horizon) is not None
+    assert infinite.get(-250, horizon) is not None
+
+
+def test_retheme_updates_existing_columns():
+    first_palette = world.build_palette(0.1)
+    second_palette = world.build_palette(0.6)
+    infinite = world.create_prebuilt_world(40, 30, first_palette)
+
+    palette_names = {block.name for block in first_palette}
+    target = None
+    for x in range(-40, 40):
+        column = infinite.column(x)
+        for offset, block in enumerate(column):
+            y = infinite.top + offset
+            if block and block.name in palette_names:
+                target = (x, y, block.color)
+                break
+        if target:
+            break
+
+    assert target is not None
+    x, y, original_color = target
+
+    infinite.retheme(second_palette)
+    updated_block = infinite.get(x, y)
+    assert updated_block is not None
+    assert updated_block.color != original_color
+    assert updated_block.name in {block.name for block in second_palette}
+
+
+def test_build_radius_check():
+    assert world.within_build_radius((5, 5), (7, 7), radius=2)
+    assert not world.within_build_radius((5, 5), (9, 9), radius=2)
+
+
+def test_world_grid_bounds_and_solidity():
+    empty = world.WorldGrid(width=4, height=3, default_block=None)
+    rock = world.BlockType("Rock", (10, 10, 10))
+
+    empty.set(1, 2, rock)
+    assert empty.get(1, 2) is rock
+    assert empty.is_solid(1, 2)
+    assert not empty.is_solid(3, 0)
+
+    with pytest.raises(IndexError):
+        empty.get(6, 0)
+
+    # Out-of-bounds should be treated as solid so the player cannot leave.
+    assert empty.is_solid(-1, 0)
+
+
+def test_infinite_world_set_and_solidity_updates():
+    palette = world.build_palette()
+    infinite = world.create_prebuilt_world(40, 30, palette)
+    target_y = infinite.horizon - 3
+
+    assert not infinite.is_solid(0, target_y)
+
+    block = list(palette)[0]
+    infinite.set(0, target_y, block)
+    assert infinite.get(0, target_y) is block
+    assert infinite.is_solid(0, target_y)
+
+    infinite.set(0, target_y, None)
+    assert infinite.get(0, target_y) is None
+    assert not infinite.is_solid(0, target_y)
+
+
+def test_infinite_world_extends_vertically_on_demand():
+    palette = world.build_palette()
+    infinite = world.create_prebuilt_world(40, 30, palette)
+
+    original_top = infinite.top
+    original_bottom = infinite.bottom
+
+    above_block = list(palette)[0]
+    below_block = list(palette)[1]
+
+    # Extending above the current ceiling should shift the tracked top.
+    new_top_y = original_top - 5
+    infinite.set(2, new_top_y, above_block)
+    assert infinite.top == new_top_y
+    assert infinite.get(2, new_top_y) is above_block
+    assert not infinite.is_solid(2, new_top_y - 1)
+
+    # Extending below the ground should grow the world downward as well.
+    new_bottom_y = original_bottom + 10
+    infinite.set(-3, new_bottom_y, below_block)
+    assert infinite.bottom >= new_bottom_y
+    assert infinite.get(-3, new_bottom_y) is below_block
+    assert infinite.is_solid(-3, new_bottom_y)
+
+
+def test_iter_window_prefills_columns():
+    palette = world.build_palette()
+    infinite = world.create_prebuilt_world(40, 30, palette)
+
+    start_x, width = -5, 11
+    rows = list(infinite.iter_window(start_x, width))
+
+    assert len(rows) == infinite.height
+    assert all(len(row) == width for row in rows)
+
+
+def test_player_state_toggle_flight_resets_velocity():
+    state = world.PlayerState(position=[0.0, 0.0], velocity=[1.0, 5.5], width=1.0, height=2.0)
+
+    assert state.toggle_flight() is True
+    assert state.flight_mode is True
+    assert state.velocity[1] == 0.0
+
+    # Toggling again should disable flight without altering velocity.
+    state.velocity[1] = -3.0
+    assert state.toggle_flight() is False
+    assert state.flight_mode is False
+    assert state.velocity[1] == -3.0
+
+
+def test_build_palette_hues_are_distinct():
+    default_palette = list(world.build_palette())
+    warm_palette = list(world.build_palette(0.1))
+
+    assert len(default_palette) == len(warm_palette)
+    assert [block.color for block in default_palette] != [block.color for block in warm_palette]
+
+    for block in default_palette + warm_palette:
+        for channel in block.color:
+            assert 0 <= channel <= 255

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,43 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[[package]]
+name = "pygame"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz", hash = "sha256:56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f", size = 14808125, upload-time = "2024-09-29T13:41:34.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ca/8f367cb9fe734c4f6f6400e045593beea2635cd736158f9fabf58ee14e3c/pygame-2.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:20349195326a5e82a16e351ed93465a7845a7e2a9af55b7bc1b2110ea3e344e1", size = 13113753, upload-time = "2024-09-29T14:26:13.751Z" },
+    { url = "https://files.pythonhosted.org/packages/83/47/6edf2f890139616b3219be9cfcc8f0cb8f42eb15efd59597927e390538cb/pygame-2.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f3935459109da4bb0b3901da9904f0a3e52028a3332a355d298b1673a334cf21", size = 12378146, upload-time = "2024-09-29T14:26:22.456Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9e/0d8aa8cf93db2d2ee38ebaf1c7b61d0df36ded27eb726221719c150c673d/pygame-2.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c31dbdb5d0217f32764797d21c2752e258e5fb7e895326538d82b5f75a0cd856", size = 13611760, upload-time = "2024-09-29T11:10:47.317Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/9e/d06adaa5cc65876bcd7a24f59f67e07f7e4194e6298130024ed3fb22c456/pygame-2.6.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:173badf82fa198e6888017bea40f511cb28e69ecdd5a72b214e81e4dcd66c3b1", size = 14298054, upload-time = "2024-09-29T11:39:53.891Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/9ae2852ebd3a7cc7d9ae7ff7919ab983e4a5c1b7a14e840732f23b2b48f6/pygame-2.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce8cc108b92de9b149b344ad2e25eedbe773af0dc41dfb24d1f07f679b558c60", size = 13977107, upload-time = "2024-09-29T11:39:56.831Z" },
+    { url = "https://files.pythonhosted.org/packages/31/df/6788fd2e9a864d0496a77670e44a7c012184b7a5382866ab0e60c55c0f28/pygame-2.6.1-cp311-cp311-win32.whl", hash = "sha256:811e7b925146d8149d79193652cbb83e0eca0aae66476b1cb310f0f4226b8b5c", size = 10250863, upload-time = "2024-09-29T11:44:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/55/ca3eb851aeef4f6f2e98a360c201f0d00bd1ba2eb98e2c7850d80aabc526/pygame-2.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:91476902426facd4bb0dad4dc3b2573bc82c95c71b135e0daaea072ed528d299", size = 10622016, upload-time = "2024-09-29T12:17:01.545Z" },
+    { url = "https://files.pythonhosted.org/packages/92/16/2c602c332f45ff9526d61f6bd764db5096ff9035433e2172e2d2cadae8db/pygame-2.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4ee7f2771f588c966fa2fa8b829be26698c9b4836f82ede5e4edc1a68594942e", size = 13118279, upload-time = "2024-09-29T14:26:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/53/77ccbc384b251c6e34bfd2e734c638233922449a7844e3c7a11ef91cee39/pygame-2.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8040ea2ab18c6b255af706ec01355c8a6b08dc48d77fd4ee783f8fc46a843bf", size = 12384524, upload-time = "2024-09-29T14:26:49.996Z" },
+    { url = "https://files.pythonhosted.org/packages/06/be/3ed337583f010696c3b3435e89a74fb29d0c74d0931e8f33c0a4246307a9/pygame-2.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47a6938de93fa610accd4969e638c2aebcb29b2fca518a84c3a39d91ab47116", size = 13587123, upload-time = "2024-09-29T11:10:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ca/b015586a450db59313535662991b34d24c1f0c0dc149cc5f496573900f4e/pygame-2.6.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33006f784e1c7d7e466fcb61d5489da59cc5f7eb098712f792a225df1d4e229d", size = 14275532, upload-time = "2024-09-29T11:39:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f2/d31e6ad42d657af07be2ffd779190353f759a07b51232b9e1d724f2cda46/pygame-2.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1206125f14cae22c44565c9d333607f1d9f59487b1f1432945dfc809aeaa3e88", size = 13952653, upload-time = "2024-09-29T11:40:01.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/8ea2a6979e6fa971702fece1747e862e2256d4a8558fe0da6364dd946c53/pygame-2.6.1-cp312-cp312-win32.whl", hash = "sha256:84fc4054e25262140d09d39e094f6880d730199710829902f0d8ceae0213379e", size = 10252421, upload-time = "2024-09-29T11:14:26.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/90/7d766d54bb95939725e9a9361f9c06b0cfbe3fe100aa35400f0a461a278a/pygame-2.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9e7396be0d9633831c3f8d5d82dd63ba373ad65599628294b7a4f8a5a01a65", size = 10624591, upload-time = "2024-09-29T11:52:54.489Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/91/718acf3e2a9d08a6ddcc96bd02a6f63c99ee7ba14afeaff2a51c987df0b9/pygame-2.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae6039f3a55d800db80e8010f387557b528d34d534435e0871326804df2a62f2", size = 13090765, upload-time = "2024-09-29T14:27:02.377Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c6/9cb315de851a7682d9c7568a41ea042ee98d668cb8deadc1dafcab6116f0/pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a3a1288e2e9b1e5834e425bedd5ba01a3cd4902b5c2bff8ed4a740ccfe98171", size = 12381704, upload-time = "2024-09-29T14:27:10.228Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/8f/617a1196e31ae3b46be6949fbaa95b8c93ce15e0544266198c2266cc1b4d/pygame-2.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27eb17e3dc9640e4b4683074f1890e2e879827447770470c2aba9f125f74510b", size = 13581091, upload-time = "2024-09-29T11:30:27.653Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/87/2851a564e40a2dad353f1c6e143465d445dab18a95281f9ea458b94f3608/pygame-2.6.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c1623180e70a03c4a734deb9bac50fc9c82942ae84a3a220779062128e75f3b", size = 14273844, upload-time = "2024-09-29T11:40:04.138Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/aa23aa2e70bcba42c989c02e7228273c30f3b44b9b264abb93eaeff43ad7/pygame-2.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef07c0103d79492c21fced9ad68c11c32efa6801ca1920ebfd0f15fb46c78b1c", size = 13951197, upload-time = "2024-09-29T11:40:06.785Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/06/29e939b34d3f1354738c7d201c51c250ad7abefefaf6f8332d962ff67c4b/pygame-2.6.1-cp313-cp313-win32.whl", hash = "sha256:3acd8c009317190c2bfd81db681ecef47d5eb108c2151d09596d9c7ea9df5c0e", size = 10249309, upload-time = "2024-09-29T11:10:23.329Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/11/17f7f319ca91824b86557e9303e3b7a71991ef17fd45286bf47d7f0a38e6/pygame-2.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:813af4fba5d0b2cb8e58f5d95f7910295c34067dcc290d34f1be59c48bd1ea6a", size = 10620084, upload-time = "2024-09-29T11:48:51.587Z" },
+]
+
+[[package]]
+name = "pymine"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pygame" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pygame", specifier = ">=2.5.0" }]


### PR DESCRIPTION
## Summary
- allow the endless world to extend vertically by generating new rows on demand while preserving palette-driven decorations
- update the pygame front end with a vertical camera, crosshair adjustments, and placement logic so exploration and building work above and below the starting window
- document the bi-directional world streaming and add regression coverage that exercises upward and downward growth

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e066fc89d083328776a7613cf3ff22