### PR TITLE
Fix crouch collision box and handle window close event

### DIFF
--- a/src/pymine/world.py
+++ b/src/pymine/world.py
@@ -277,9 +277,21 @@ class PlayerState:
     velocity: List[float]
     width: float
     height: float
+    standing_height: float | None = None
+    crouching_height: float | None = None
     on_ground: bool = False
     crouching: bool = False
     flight_mode: bool = False
+
+    def __post_init__(self) -> None:
+        # Preserve the original constructor signature where ``height`` defined the
+        # standing collision size.  The crouching height defaults to a gentle
+        # squeeze so the player still feels responsive while ducking under
+        # blocks.
+        if self.standing_height is None:
+            self.standing_height = self.height
+        if self.crouching_height is None:
+            self.crouching_height = self.standing_height * 0.6
 
     def rect(self) -> Tuple[float, float, float, float]:
         return (*self.position, self.width, self.height)


### PR DESCRIPTION
## Summary
- track standing and crouching heights on the player state and update the stance hitbox to actually squeeze while crouching
- prevent standing up into solid tiles so the player stays crouched when there is no headroom
- treat native window close events the same as quit events so the game exits when the window X is clicked

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11b3d67e08332b4256d2fa8f3a5ed