### PR TITLE
Ensure player spawn is grounded

### DIFF
--- a/src/pymine/game.py
+++ b/src/pymine/game.py
@@ -21,6 +21,7 @@ from .world import (
     PlayerState,
     build_palette,
     create_prebuilt_world,
+    place_player_on_surface,
     within_build_radius,
 )
 
@@ -412,6 +413,7 @@ def main() -> None:
     world = create_prebuilt_world(WORLD_WIDTH, WORLD_HEIGHT, palette)
 
     player = PlayerState(position=[BLOCK_SIZE * 3.0, BLOCK_SIZE * 10.0], velocity=[0.0, 0.0], width=BLOCK_SIZE * 0.6, height=BLOCK_SIZE * 0.9)
+    place_player_on_surface(world, player, block_size=BLOCK_SIZE)
 
     fonts = {
         "hud": pygame.font.SysFont("arial", 18),


### PR DESCRIPTION
## Summary
- add a reusable `place_player_on_surface` helper so spawns snap to the nearest safe surface instead of intersecting blocks
- call the helper during game start-up to stop the player from falling through freshly generated terrain
- cover the new behaviour with unit tests for grounded placement, embedded spawns, and unsupported columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2519188a88332add0c99226052345